### PR TITLE
Add remove-svn-keywords.sh

### DIFF
--- a/remove-svn-keywords.sh
+++ b/remove-svn-keywords.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+shellfileOne=/tmp/$$svn-remove-keywordsOne.sh
+shellfileAll=/tmp/$$svn-remove-keywordsAll.sh
+
+
+cat <<EOF >$shellfileOne
+#!/bin/sh
+
+filename=\$1
+git checkout "\$filename" &&
+sed <"\$filename" \
+  -e 's%Version:.*Revision%XXXXXXXXXXXXXXXXXX\$%' \
+  -e 's%Modified [bB]y:.*Author%XXXXXXXXXXXXXXXXXX\$%' \
+  -e 's%Last Modified:.*Date%XXXXXXXXXXXXXXXXXX\$%' \
+  -e 's%HeadURL:.*URL%XXXXXXXXXXXXXXXXXX\$%' \
+>"\$filename.new" &&
+if grep XXXXXXXXXXXXXXXXXX "\$filename.new" >/dev/null; then
+	grep -v XXXXXXXXXXXXXXXXXX "\$filename.new" >"\$filename" &&
+	git diff "\$filename"
+fi
+rm "\$filename.new"
+EOF
+
+git ls-files | xargs egrep -l "Version:.*Revision|Modified [bB]y:.*Author|Last Modified:.*Date|HeadURL:.*URL%" | sed -e "s%^%$shellfileOne %" >"$shellfileAll" &&
+chmod +x $shellfileAll $shellfileOne &&
+$shellfileAll


### PR DESCRIPTION
When comparing different Git trees there may be an unwanted diff
inlines like this:
"Version:        $Revision$"
against
"Version:        $Revision: 13567 $"

This may happen when:
repo A) is created from a ZIP file, put under SVN, maintained here,
and later converted to Git.
repo B) is the upstream Git, converted from SVN into Git.

Now the differences between A) and B) should be found, by running
"git diff".

In this case many files may differ only in the SVN headers.
These headers don't have a major meaning under Git,
since all Git related tools are able to get this information from Git.
